### PR TITLE
diagnostic_msgs headers are used in the headers

### DIFF
--- a/kinesis_video_msgs/package.xml
+++ b/kinesis_video_msgs/package.xml
@@ -14,7 +14,8 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
-  <build_depend>diagnostic_msgs</build_depend>
+
+  <depend>diagnostic_msgs</depend>
 
   <exec_depend>message_runtime</exec_depend>
 </package>


### PR DESCRIPTION
This means it needs to be at least a build_export depend. And likely the messages will be used at runtime so I'm going to make it a full depend tag.

Resolve issue discovered in http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__kinesis_video_streamer__ubuntu_xenial_amd64__binary/4/console


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
