### PR TITLE
Use separate node and stream config in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ An example launch file called `sample_application.launch` is included in this pr
 
 
 ## Configuration File and Parameters
-Applies to the `kinesis_video_streamer` node. For configuring the encoder node, please see the README for the [H264 Video Encoder node]. An example configuration file called `stream0.yaml` is provided. When the parameters are absent in
+Applies to the `kinesis_video_streamer` node. For configuring the encoder node, please see the README for the [H264 Video Encoder node]. An example configuration file called `stream_sample_configuration.yaml` is provided. When the parameters are absent in
 the ROS parameter server, default values are used. Since this node makes HTTP requests to AWS endpoints, valid AWS credentials must be provided (this can be done via the environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` - see https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html).
 
 ### Node-wide configuration parameters

--- a/kinesis_video_streamer/config/node_sample_configuration.yaml
+++ b/kinesis_video_streamer/config/node_sample_configuration.yaml
@@ -1,27 +1,3 @@
-# Kinesis Video Stream name. If a stream by the given name doesn't exist, it will be created.
-stream_name: "testStream"
-
-# Topic name to subscribe and receive the image/video data from.
-subscription_topic: /video/encoded
-
-# Topic type
-  # 1: KinesisVideoFrame transport, enabling h264 streaming
-  # 2: sensor_msgs::Image transport.
-  # 3: Like 1 but with AWS Rekognition support built-in. Results will be read from 'rekognition_data_stream' and published onto 'rekognition_topic_name'.
-topic_type: 1
-
-#### If topic_type is 3, we expect the following parameters.
-### The Kinesis Data Stream from which to read Rekognition's analysis results.
-# rekognition_data_stream: "kinesis-sample"
-### The ROS topic on which to publish the results.
-# rekognition_topic_name: "/rekognition/results"
-
-# Frame rate should match the encoder's (and the camera's) frame rate.
-frame_rate: 30
-
-# Rather than using the input's timestamps, let the Producer SDK create timestamps as the frames arrive.
-frame_timecodes: false
-
 # This is the AWS Client Configuration used by the AWS service client in the Node. If given the node will load the
 # provided configuration when initializing the client.
 aws_client_configuration:

--- a/kinesis_video_streamer/config/stream_sample_configuration.yaml
+++ b/kinesis_video_streamer/config/stream_sample_configuration.yaml
@@ -1,0 +1,23 @@
+# Kinesis Video Stream name. If a stream by the given name doesn't exist, it will be created.
+stream_name: "testStream"
+
+# Topic name to subscribe and receive the image/video data from.
+subscription_topic: /video/encoded
+
+# Topic type
+  # 1: KinesisVideoFrame transport, enabling h264 streaming
+  # 2: sensor_msgs::Image transport.
+  # 3: Like 1 but with AWS Rekognition support built-in. Results will be read from 'rekognition_data_stream' and published onto 'rekognition_topic_name'.
+topic_type: 1
+
+#### If topic_type is 3, we expect the following parameters.
+### The Kinesis Data Stream from which to read Rekognition's analysis results.
+# rekognition_data_stream: "kinesis-sample"
+### The ROS topic on which to publish the results.
+# rekognition_topic_name: "/rekognition/results"
+
+# Frame rate should match the encoder's (and the camera's) frame rate.
+frame_rate: 30
+
+# Rather than using the input's timestamps, let the Producer SDK create timestamps as the frames arrive.
+frame_timecodes: false

--- a/kinesis_video_streamer/launch/kinesis_video_streamer.launch
+++ b/kinesis_video_streamer/launch/kinesis_video_streamer.launch
@@ -14,12 +14,15 @@
 <launch>
     <!-- If a node_name argument is provided by the caller then we will set the node's name to that value -->
     <arg name="node_name" default="kinesis_video_streamer" />
-    <!-- If a stream config file argument is provided by the caller then we will load it into the node's namespace -->
-    <arg name="config_file" default="" />
+    <!-- If a node config file argument is provided by the caller then we will load it into the streams's namespace -->
+    <arg name="node_config_file" default="" />
+    <!-- If a stream config file argument is provided by the caller then we will load it -->
+    <arg name="stream_config_file" default="" />
 
     <node name="$(arg node_name)" pkg="kinesis_video_streamer" type="kinesis_video_streamer">
         <!-- If the caller specified a config file then load it here. -->
-        <rosparam if="$(eval config_file!='')" command="load" file="$(arg config_file)" ns="kinesis_video/stream0" />
+        <rosparam if="$(eval node_config_file!='')" command="load" file="$(arg node_config_file)" />
+        <rosparam if="$(eval stream_config_file!='')" command="load" file="$(arg stream_config_file)" ns="kinesis_video/stream0" />
 
         <param name="kinesis_video/log4cplus_config" value="$(find kinesis_video_streamer)/kvs_log_configuration" />
         <param name="kinesis_video/stream_count" value="1" />

--- a/kinesis_video_streamer/launch/sample_application.launch
+++ b/kinesis_video_streamer/launch/sample_application.launch
@@ -3,12 +3,14 @@
 <launch>
     <!-- Custom Nodes would be launched here -->
 
-    <arg name="config_file" default="$(find kinesis_video_streamer)/config/sample_configuration.yaml"/>
+    <arg name="node_config_file" default="$(find kinesis_video_streamer)/config/node_sample_configuration.yaml"/>
+    <arg name="stream_config_file" default="$(find kinesis_video_streamer)/config/stream_sample_configuration.yaml"/>
 
     <include file="$(find kinesis_video_streamer)/launch/kinesis_video_streamer.launch" >
-        <!-- The configuration can either be passed in using the "config_file" parameter or by using a rosparam tag
-                to load the config into the parameter server -->
-        <arg name="config_file" value="$(arg config_file)"/>
+        <!-- The configuration can either be passed in using the "node_config_file" and "stream_config_file" parameters
+         or by using a rosparam tag to load the config into the parameter server -->
+        <arg name="node_config_file" value="$(arg node_config_file)"/>
+        <arg name="stream_config_file" value="$(arg stream_config_file)"/>
     </include>
 
     <include file="$(find h264_video_encoder)/launch/sample_application.launch" />


### PR DESCRIPTION
*Issue #, if available:* #2 

*Description of changes:* This changes splits the default configuration file for kinesis_video_streamer into two, so there is a node wide configuration for AWS client configuration, and another file for the single stream that is used in sample_application.launch. Without this change `roslaunch kinesis_video_streamer sample_application.launch` is not able to use the AWS client configuration defined on `kinesis_video_streamer/config/sample_configuration.yaml`, and `roslaunch kinesis_video_streamer sample_application.launch` crashes if the AWS region is not defined on `~/.aws/config` for a default profile

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
