### PR TITLE
Restrict aws robotics dependencies

### DIFF
--- a/kinesis_video_streamer/package.xml
+++ b/kinesis_video_streamer/package.xml
@@ -13,11 +13,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>aws_common</depend>
-  <depend>aws_ros1_common</depend>
-  <depend>kinesis_manager</depend>
+  <depend version_lt='2.0.0'>aws_common</depend>
+  <depend version_lt='2.0.0'>aws_ros1_common</depend>
+  <depend version_lt='2.0.0'>kinesis_manager</depend>
   <depend>roscpp</depend>
-  <depend>kinesis_video_msgs</depend>
+  <depend version_lt='2.0.0'>kinesis_video_msgs</depend>
   <depend>image_transport</depend>
   <depend>std_msgs</depend>
 


### PR DESCRIPTION
*Description of changes:*
Set aws-robotics dependencies to less than 2.0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
