### PR TITLE
Update to use non-legacy ParameterReader API

### DIFF
--- a/kinesis_video_streamer/include/kinesis_video_streamer/ros_stream_subscription_installer.h
+++ b/kinesis_video_streamer/include/kinesis_video_streamer/ros_stream_subscription_installer.h
@@ -20,7 +20,6 @@
 #include <kinesis_video_msgs/KinesisVideoFrame.h>
 #include <kinesis_video_streamer/subscriber_callbacks.h>
 
-using namespace Aws::Utils::Logging;
 
 namespace Aws {
 namespace Kinesis {

--- a/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
+++ b/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
@@ -104,7 +104,7 @@ TEST_F(KinesisVideoStreamerTestBase, sanity)
   parameter_reader.string_map_.insert(
     {string("kinesis_video/stream0/subscription_topic"), "topic-name"});
   unique_ptr<StreamDefinition> stream_definition =
-    real_stream_definition_provider.GetStreamDefinition("", parameter_reader, nullptr, 0);
+    real_stream_definition_provider.GetStreamDefinition(ParameterPath(""), parameter_reader, nullptr, 0);
   test_data.get_stream_definition_return_value = (StreamDefinition *)stream_definition.release();
   KinesisManagerStatus setup_result = stream_manager->KinesisVideoStreamerSetup();
   ASSERT_TRUE(KINESIS_MANAGER_STATUS_SUCCEEDED(setup_result));
@@ -155,7 +155,7 @@ TEST_F(KinesisVideoStreamerTestBase, streamInitializationFailures)
   for (int idx = 0; idx < initialization_attempts; idx++) {
     parameter_reader.int_map_.at("kinesis_video/stream_count") = stream_count;
     unique_ptr<StreamDefinition> stream_definition =
-      real_stream_definition_provider.GetStreamDefinition("", parameter_reader, nullptr, 0);
+      real_stream_definition_provider.GetStreamDefinition(ParameterPath(""), parameter_reader, nullptr, 0);
     test_data.get_stream_definition_return_value = (StreamDefinition *)stream_definition.release();
     setup_result = stream_manager->KinesisVideoStreamerSetup();
     ASSERT_TRUE(KINESIS_MANAGER_STATUS_FAILED(setup_result));
@@ -177,7 +177,7 @@ TEST_F(KinesisVideoStreamerTestBase, streamInitializationFailures)
   for (int idx = 0; idx < initialization_attempts; idx++) {
     parameter_reader.int_map_.at("kinesis_video/stream_count") = stream_count;
     unique_ptr<StreamDefinition> stream_definition =
-      real_stream_definition_provider.GetStreamDefinition("", parameter_reader, nullptr, 0);
+      real_stream_definition_provider.GetStreamDefinition(ParameterPath(""), parameter_reader, nullptr, 0);
     test_data.get_stream_definition_return_value = (StreamDefinition *)stream_definition.release();
     KinesisManagerStatus setup_result = stream_manager->KinesisVideoStreamerSetup();
     ASSERT_TRUE(KINESIS_MANAGER_STATUS_FAILED(setup_result));
@@ -250,7 +250,7 @@ protected:
     parameter_reader.string_map_.insert(
       {string("kinesis_video/stream0/subscription_topic"), subscription_topic_name});
     unique_ptr<StreamDefinition> stream_definition =
-      real_stream_definition_provider.GetStreamDefinition("kinesis_video/stream0/",
+      real_stream_definition_provider.GetStreamDefinition(ParameterPath("kinesis_video", "stream0"),
                                                           parameter_reader, nullptr, 0);
     test_data.get_stream_definition_return_value = (StreamDefinition *)stream_definition.release();
     KinesisManagerStatus setup_result = stream_manager->KinesisVideoStreamerSetup();
@@ -286,7 +286,7 @@ protected:
     parameter_reader.string_map_.at("kinesis_video/stream0/subscription_topic") =
       subscription_topic_name;
     stream_definition = real_stream_definition_provider.GetStreamDefinition(
-      "kinesis_video/stream0/", parameter_reader, nullptr, 0);
+      ParameterPath("kinesis_video", "stream0"), parameter_reader, nullptr, 0);
     test_data.get_stream_definition_return_value = (StreamDefinition *)stream_definition.release();
     setup_result = stream_manager->KinesisVideoStreamerSetup();
     ASSERT_TRUE(KINESIS_MANAGER_STATUS_SUCCEEDED(setup_result));
@@ -318,7 +318,7 @@ protected:
     parameter_reader.string_map_.insert(
       {"kinesis_video/stream0/rekognition_data_stream", "kinesis-sample"});
     stream_definition = real_stream_definition_provider.GetStreamDefinition(
-      "kinesis_video/stream0/", parameter_reader, nullptr, 0);
+      ParameterPath("kinesis_video", "stream0"), parameter_reader, nullptr, 0);
     test_data.get_stream_definition_return_value = (StreamDefinition *)stream_definition.release();
     setup_result = stream_manager->KinesisVideoStreamerSetup();
     ASSERT_TRUE(KINESIS_MANAGER_STATUS_SUCCEEDED(setup_result));

--- a/kinesis_video_streamer/test/kinesis_video_streamer_test_utils.h
+++ b/kinesis_video_streamer/test/kinesis_video_streamer_test_utils.h
@@ -21,8 +21,11 @@
 #include <kinesis_video_streamer/streamer.h>
 
 using namespace std;
+using namespace com::amazonaws::kinesis::video;
 using namespace Aws;
+using namespace Aws::Client;
 using namespace Aws::Kinesis;
+
 
 struct TestData
 {
@@ -158,8 +161,9 @@ public:
   {
   }
 
-  AwsError ReadInt(const char * name, int & out) const override
+  AwsError ReadParam(const ParameterPath & param_path, int & out) const override
   {
+    std::string name = FormatParameterPath(param_path);
     if (int_map_.count(name) > 0) {
       out = int_map_.at(name);
       return AWS_ERR_OK;
@@ -167,8 +171,9 @@ public:
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadBool(const char * name, bool & out) const
+  AwsError ReadParam(const ParameterPath & param_path, bool & out) const
   {
+    std::string name = FormatParameterPath(param_path);
     if (bool_map_.count(name) > 0) {
       out = bool_map_.at(name);
       return AWS_ERR_OK;
@@ -176,8 +181,9 @@ public:
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadStdString(const char * name, string & out) const
+  AwsError ReadParam(const ParameterPath & param_path, string & out) const
   {
+    std::string name = FormatParameterPath(param_path);
     if (string_map_.count(name) > 0) {
       out = string_map_.at(name);
       return AWS_ERR_OK;
@@ -185,13 +191,14 @@ public:
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadString(const char * name, Aws::String & out) const
+  AwsError ReadParam(const ParameterPath & param_path, Aws::String & out) const
   {
     return AWS_ERR_EMPTY;
   }
 
-  AwsError ReadMap(const char * name, map<string, string> & out) const
+  AwsError ReadParam(const ParameterPath & param_path, map<string, string> & out) const
   {
+    std::string name = FormatParameterPath(param_path);
     if (map_map_.count(name) > 0) {
       out = map_map_.at(name);
       return AWS_ERR_OK;
@@ -199,12 +206,12 @@ public:
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadList(const char * name, std::vector<std::string> & out) const
+  AwsError ReadParam(const ParameterPath & param_path, std::vector<std::string> & out) const
   {
     return AWS_ERR_EMPTY;
   }
 
-  AwsError ReadDouble(const char * name, double & out) const
+  AwsError ReadParam(const ParameterPath & param_path, double & out) const
   {
     return AWS_ERR_EMPTY;
   }
@@ -215,7 +222,7 @@ public:
   map<string, map<string, string>> map_map_;
 
 private:
-  std::string FormatParameterPath(const Client::ParameterPath & param_path) const
+  std::string FormatParameterPath(const ParameterPath & param_path) const
   {
     return param_path.get_resolved_path('/', '/');
   }


### PR DESCRIPTION
*Description of changes:*

We have decided to remove the legacy portions of the ParameterReader API. ParameterReader will now only accept ParameterPath objects for addressing parameters. Calls to ReadParam need to be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
