### PR TITLE
Refactor StreamerNode class, add tests

### DIFF
--- a/kinesis_video_streamer/CMakeLists.txt
+++ b/kinesis_video_streamer/CMakeLists.txt
@@ -29,7 +29,7 @@ catkin_package()
 ###########
 ## Declare a C++ executable
 set(KINESIS_VIDEO_STREAMER_SRC src/ros_stream_subscription_installer.cpp src/subscriber_callbacks.cpp src/streamer.cpp)
-add_executable(${PROJECT_NAME} ${KINESIS_VIDEO_STREAMER_SRC})
+add_executable(${PROJECT_NAME} src/main.cpp ${KINESIS_VIDEO_STREAMER_SRC})
 add_library(${PROJECT_NAME}_lib ${KINESIS_VIDEO_STREAMER_SRC})
 ## Specify include directories
 target_include_directories(${PROJECT_NAME} PRIVATE include ${catkin_INCLUDE_DIRS} ${kinesis_manager_INCLUDE_DIRS})
@@ -58,6 +58,10 @@ install(FILES kvs_log_configuration DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATI
 
 if(CATKIN_ENABLE_TESTING)
     find_package(rostest REQUIRED)
+    
+    include_directories(/usr/include/gmock /usr/src/gmock)
+    add_library(libgmock /usr/src/gmock/src/gmock-all.cc)
+    
     add_rostest_gtest(test_kinesis_video_streamer
       test/test_kinesis_video_streamer.test
       test/kinesis_video_streamer_test.cpp)
@@ -65,4 +69,11 @@ if(CATKIN_ENABLE_TESTING)
     target_link_libraries(test_kinesis_video_streamer
                           ${PROJECT_NAME}_lib
                           ${catkin_LIBRARIES})
+                          
+    add_rostest_gtest(test_streamer_node 
+    	test/test_streamer_node.test
+    	test/streamer_node_test.cpp)
+    target_include_directories(test_streamer_node PRIVATE include ${catkin_INCLUDE_DIRS} ${kinesis_manager_INCLUDE_DIRS})
+    target_link_libraries(test_streamer_node ${PROJECT_NAME}_lib
+      ${GTEST_LIBRARIES} libgmock ${catkin_LIBRARIES})
 endif()

--- a/kinesis_video_streamer/include/kinesis_video_streamer/ros_stream_subscription_installer.h
+++ b/kinesis_video_streamer/include/kinesis_video_streamer/ros_stream_subscription_installer.h
@@ -67,7 +67,7 @@ public:
    * custom callbacks.
    * @return true on success
    */
-  bool SetDefaultCallbacks()
+  virtual bool SetDefaultCallbacks()
   {
     bool status = true;
     ImageTransportCallbackFn image_transport_callback;

--- a/kinesis_video_streamer/include/kinesis_video_streamer/streamer.h
+++ b/kinesis_video_streamer/include/kinesis_video_streamer/streamer.h
@@ -14,6 +14,9 @@
  */
 #pragma once
 
+#include <ros/ros.h>
+#include <aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h>
+
 namespace Aws {
 namespace Kinesis {
 /**
@@ -25,7 +28,28 @@ namespace Kinesis {
  * validate (or fix) the order by the receiving application.
  */
 constexpr uint32_t kDefaultNumberOfSpinnerThreads = 1;
-const char * kSpinnerThreadCountOverrideParameter = "spinner_thread_count";
+
+class StreamerNode : public ros::NodeHandle
+{
+public:
+  StreamerNode(const std::string & ns);
+  
+  ~StreamerNode() = default;
+  
+  KinesisManagerStatus Initialize();
+  
+  KinesisManagerStatus InitializeStreamSubscriptions();
+  
+  void Spin();
+  
+  void set_subscription_installer(std::shared_ptr<RosStreamSubscriptionInstaller> subscription_installer);
+  
+private:
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader_;
+  std::shared_ptr<RosStreamSubscriptionInstaller> subscription_installer_;
+  std::shared_ptr<KinesisStreamManager> stream_manager_;
+  StreamDefinitionProvider stream_definition_provider_;
+};
 
 }  // namespace Kinesis
 }  // namespace Aws

--- a/kinesis_video_streamer/src/main.cpp
+++ b/kinesis_video_streamer/src/main.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/core/Aws.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws_common/sdk_utils/aws_error.h>
+#include <aws_common/sdk_utils/client_configuration_provider.h>
+#include <aws_ros1_common/sdk_utils/logging/aws_ros_logger.h>
+#include <aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h>
+#include <kinesis_video_streamer/ros_stream_subscription_installer.h>
+#include <kinesis_video_streamer/streamer.h>
+#include <kinesis_video_streamer/subscriber_callbacks.h>
+#include <ros/ros.h>
+
+using namespace Aws::Client;
+using namespace Aws::Kinesis;
+
+
+#ifndef RETURN_CODE_MASK
+#define RETURN_CODE_MASK (0xff) /* Process exit code is in range (0, 255) */
+#endif
+
+#ifndef UNKNOWN_ERROR_KINESIS_VIDEO_EXIT_CODE
+#define UNKNOWN_ERROR_KINESIS_VIDEO_EXIT_CODE (0xf0)
+#endif
+
+constexpr char kNodeName[] = "kinesis_video_streamer";
+
+int shutdown(Aws::SDKOptions options, int return_code) {
+  AWS_LOG_INFO(__func__, "Shutting down Kinesis Video Node...");
+  Aws::Utils::Logging::ShutdownAWSLogging();
+  Aws::ShutdownAPI(options);
+  return return_code & RETURN_CODE_MASK;
+}
+
+int main(int argc, char * argv[])
+{
+  int return_code = UNKNOWN_ERROR_KINESIS_VIDEO_EXIT_CODE;
+
+  ros::init(argc, argv, kNodeName);
+  StreamerNode streamer("~");
+
+  Aws::Utils::Logging::InitializeAWSLogging(
+    Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>(kNodeName));
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+
+  KinesisManagerStatus status = streamer.Initialize();
+  if (!KINESIS_MANAGER_STATUS_SUCCEEDED(status)) {
+    return shutdown(options, status);
+  }
+  
+  status = streamer.InitializeStreamSubscriptions();
+  if (!KINESIS_MANAGER_STATUS_SUCCEEDED(status)) {
+    return shutdown(options, status);
+  }
+  
+  AWS_LOG_INFO(__func__, "Starting Kinesis Video Node...");
+  streamer.Spin();
+  
+  return shutdown(options, return_code);
+}

--- a/kinesis_video_streamer/src/ros_stream_subscription_installer.cpp
+++ b/kinesis_video_streamer/src/ros_stream_subscription_installer.cpp
@@ -48,7 +48,7 @@ bool RosStreamSubscriptionInstaller::SetupKinesisVideoFrameTransport(
     AWS_LOG_ERROR(__func__, "Invalid callback was provided");
     return false;
   }
-  SubscriberSetupFn kinesis_video_frame_setup_closure = 
+  SubscriberSetupFn kinesis_video_frame_setup_closure =
     [this, callback](const StreamSubscriptionDescriptor & descriptor) -> bool {
     boost::function<void(const kinesis_video_msgs::KinesisVideoFrame::ConstPtr &)> callback_wrapper;
     callback_wrapper = [this, callback, descriptor](

--- a/kinesis_video_streamer/src/ros_stream_subscription_installer.cpp
+++ b/kinesis_video_streamer/src/ros_stream_subscription_installer.cpp
@@ -48,7 +48,7 @@ bool RosStreamSubscriptionInstaller::SetupKinesisVideoFrameTransport(
     AWS_LOG_ERROR(__func__, "Invalid callback was provided");
     return false;
   }
-  SubscriberSetupFn kinesis_video_frame_setup_closure =
+  SubscriberSetupFn kinesis_video_frame_setup_closure = 
     [this, callback](const StreamSubscriptionDescriptor & descriptor) -> bool {
     boost::function<void(const kinesis_video_msgs::KinesisVideoFrame::ConstPtr &)> callback_wrapper;
     callback_wrapper = [this, callback, descriptor](

--- a/kinesis_video_streamer/src/streamer.cpp
+++ b/kinesis_video_streamer/src/streamer.cpp
@@ -35,107 +35,91 @@ using namespace Aws::Kinesis;
 #define UNKNOWN_ERROR_KINESIS_VIDEO_EXIT_CODE (0xf0)
 #endif
 
-
 constexpr char kNodeName[] = "kinesis_video_streamer";
+const char * kSpinnerThreadCountOverrideParameter = "spinner_thread_count";
 
-class StreamerNode : public ros::NodeHandle
+namespace Aws {
+namespace Kinesis {
+  
+StreamerNode::StreamerNode(const std::string & ns = std::string()) : ros::NodeHandle(ns)
 {
-public:
-  StreamerNode(const std::string & ns = std::string()) : ros::NodeHandle(ns)
-  {
-    parameter_reader_ = std::make_shared<Ros1NodeParameterReader>();
-    subscription_installer_ = std::make_shared<RosStreamSubscriptionInstaller>(*this);
+  parameter_reader_ = std::make_shared<Ros1NodeParameterReader>();
+  subscription_installer_ = std::make_shared<RosStreamSubscriptionInstaller>(*this);
 
-    /* Log4cplus setup for the Kinesis Producer SDK */
-    std::string log4cplus_config;
-    parameter_reader_->ReadParam(
-      GetKinesisVideoParameter(kStreamParameters.log4cplus_config), log4cplus_config);
-    if (!log4cplus_config.empty()) {
-      log4cplus::PropertyConfigurator::doConfigure(log4cplus_config);
-    } else {
-      log4cplus::BasicConfigurator configurator;
-      configurator.configure();
-    }
-  }
-
-  KinesisManagerStatus Initialize()
-  {
-    ClientConfigurationProvider configuration_provider(parameter_reader_);
-    ClientConfiguration aws_sdk_config =
-      configuration_provider.GetClientConfiguration();
-    /* Set up subscription callbacks */
-    if (!subscription_installer_->SetDefaultCallbacks()) {
-      AWS_LOG_FATAL(__func__, "Failed to set up subscription callbacks.");
-      return KINESIS_MANAGER_STATUS_ERROR_BASE;
-    }
-    auto kinesis_client = std::unique_ptr<KinesisClient>(
-      Aws::New<Aws::Kinesis::KinesisClientFacade>(__func__, aws_sdk_config));
-    stream_manager_ = std::make_shared<KinesisStreamManager>(
-      parameter_reader_.get(), &stream_definition_provider_, subscription_installer_.get(),
-      std::move(kinesis_client));
-    subscription_installer_->set_stream_manager(stream_manager_.get());
-    /* Initialization of video producer */
-    KinesisManagerStatus initialize_video_producer_result =
-      stream_manager_->InitializeVideoProducer(aws_sdk_config.region.c_str());
-    if (KINESIS_MANAGER_STATUS_FAILED(initialize_video_producer_result)) {
-      AWS_LOGSTREAM_FATAL(__func__, "Failed to initialize video producer. Error code: "
-                                      << initialize_video_producer_result);
-      return initialize_video_producer_result;
-    }
-    /* Set up subscriptions and get ready to start streaming */
-    KinesisManagerStatus streamer_setup_result = stream_manager_->KinesisVideoStreamerSetup();
-    if (KINESIS_MANAGER_STATUS_SUCCEEDED(streamer_setup_result)) {
-      AWS_LOG_DEBUG(__func__, "KinesisVideoStreamerSetup completed successfully.");
-    } else {
-      AWS_LOGSTREAM_ERROR(__func__, "KinesisVideoStreamerSetup failed with error code : "
-                                      << streamer_setup_result << ". Exiting");
-      return streamer_setup_result;
-    }
-    return KINESIS_MANAGER_STATUS_SUCCESS;
-  }
-
-  void Spin()
-  {
-    uint32_t spinner_thread_count = kDefaultNumberOfSpinnerThreads;
-    int spinner_thread_count_input;
-    if (Aws::AwsError::AWS_ERR_OK ==
-        parameter_reader_->ReadParam(ParameterPath(kSpinnerThreadCountOverrideParameter),
-                                   spinner_thread_count_input)) {
-      spinner_thread_count = static_cast<uint32_t>(spinner_thread_count_input);
-    }
-    ros::MultiThreadedSpinner spinner(spinner_thread_count);
-    spinner.spin();
-  }
-
-private:
-  std::shared_ptr<Ros1NodeParameterReader> parameter_reader_;
-  std::shared_ptr<RosStreamSubscriptionInstaller> subscription_installer_;
-  std::shared_ptr<KinesisStreamManager> stream_manager_;
-  StreamDefinitionProvider stream_definition_provider_;
-};
-
-int main(int argc, char * argv[])
-{
-  int return_code = UNKNOWN_ERROR_KINESIS_VIDEO_EXIT_CODE;
-
-  ros::init(argc, argv, kNodeName);
-  StreamerNode streamer("~");
-
-  Aws::Utils::Logging::InitializeAWSLogging(
-    Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>(kNodeName));
-  Aws::SDKOptions options;
-  Aws::InitAPI(options);
-
-  KinesisManagerStatus status = streamer.Initialize();
-  if (KINESIS_MANAGER_STATUS_SUCCEEDED(status)) {
-    AWS_LOG_INFO(__func__, "Starting Kinesis Video Node...");
-    streamer.Spin();
+  /* Log4cplus setup for the Kinesis Producer SDK */
+  std::string log4cplus_config;
+  parameter_reader_->ReadParam(
+    GetKinesisVideoParameter(kStreamParameters.log4cplus_config), log4cplus_config);
+  if (!log4cplus_config.empty()) {
+    log4cplus::PropertyConfigurator::doConfigure(log4cplus_config);
   } else {
-    return_code = status;
+    log4cplus::BasicConfigurator configurator;
+    configurator.configure();
   }
-
-  AWS_LOG_INFO(__func__, "Shutting down Kinesis Video Node...");
-  Aws::Utils::Logging::ShutdownAWSLogging();
-  Aws::ShutdownAPI(options);
-  return return_code & RETURN_CODE_MASK;
 }
+
+KinesisManagerStatus StreamerNode::Initialize()
+{
+  ClientConfigurationProvider configuration_provider(parameter_reader_);
+  ClientConfiguration aws_sdk_config =
+    configuration_provider.GetClientConfiguration();
+  /* Set up subscription callbacks */
+  if (!subscription_installer_->SetDefaultCallbacks()) {
+    AWS_LOG_FATAL(__func__, "Failed to set up subscription callbacks.");
+    return KINESIS_MANAGER_STATUS_ERROR_BASE;
+  }
+  auto kinesis_client = std::unique_ptr<KinesisClient>(
+    Aws::New<Aws::Kinesis::KinesisClientFacade>(__func__, aws_sdk_config));
+  stream_manager_ = std::make_shared<KinesisStreamManager>(
+    parameter_reader_.get(), &stream_definition_provider_, subscription_installer_.get(),
+    std::move(kinesis_client));
+  subscription_installer_->set_stream_manager(stream_manager_.get());
+  /* Initialization of video producer */
+  KinesisManagerStatus initialize_video_producer_result =
+    stream_manager_->InitializeVideoProducer(aws_sdk_config.region.c_str());
+  if (KINESIS_MANAGER_STATUS_FAILED(initialize_video_producer_result)) {
+    fprintf(stderr, "Failed to initialize video producer");
+    AWS_LOGSTREAM_FATAL(__func__, "Failed to initialize video producer. Error code: "
+                                    << initialize_video_producer_result);
+    return initialize_video_producer_result;
+  }
+  
+  return KINESIS_MANAGER_STATUS_SUCCESS;
+}
+
+KinesisManagerStatus StreamerNode::InitializeStreamSubscriptions() 
+{
+  /* Set up subscriptions and get ready to start streaming */
+  KinesisManagerStatus streamer_setup_result = stream_manager_->KinesisVideoStreamerSetup();
+  if (KINESIS_MANAGER_STATUS_SUCCEEDED(streamer_setup_result)) {
+    AWS_LOG_DEBUG(__func__, "KinesisVideoStreamerSetup completed successfully.");
+  } else {
+    fprintf(stderr, "Failed to setup the kinesis video streamer");
+    AWS_LOGSTREAM_ERROR(__func__, "KinesisVideoStreamerSetup failed with error code : "
+                                    << streamer_setup_result << ". Exiting");
+    return streamer_setup_result;
+  }
+  
+  return KINESIS_MANAGER_STATUS_SUCCESS;
+}
+
+void StreamerNode::Spin()
+{
+  uint32_t spinner_thread_count = kDefaultNumberOfSpinnerThreads;
+  int spinner_thread_count_input;
+  if (Aws::AwsError::AWS_ERR_OK ==
+      parameter_reader_->ReadParam(ParameterPath(kSpinnerThreadCountOverrideParameter),
+                                 spinner_thread_count_input)) {
+    spinner_thread_count = static_cast<uint32_t>(spinner_thread_count_input);
+  }
+  ros::MultiThreadedSpinner spinner(spinner_thread_count);
+  spinner.spin();
+}
+
+void StreamerNode::set_subscription_installer(std::shared_ptr<RosStreamSubscriptionInstaller> subscription_installer)
+{
+  subscription_installer_ = subscription_installer;
+}
+
+}  // namespace Kinesis
+}  // namespace Aws

--- a/kinesis_video_streamer/src/subscriber_callbacks.cpp
+++ b/kinesis_video_streamer/src/subscriber_callbacks.cpp
@@ -54,7 +54,7 @@ void KinesisVideoFrameTransportCallback(
     KinesisManagerStatus update_codec_data_result =
       stream_manager.ProcessCodecPrivateDataForStream(stream_name, frame_msg->codec_private_data);
     if (KINESIS_MANAGER_STATUS_FAILED(update_codec_data_result)) {
-      AWS_LOGSTREAM_WARN(
+        AWS_LOGSTREAM_WARN(
         __func__, stream_name.c_str()
                     << " failed updating codec data, error code: " << update_codec_data_result
                     << ". Continuing streaming as a best effort, but you might not be able to "

--- a/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
+++ b/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
@@ -110,6 +110,15 @@ TEST_F(KinesisVideoStreamerTestBase, sanity)
   ASSERT_TRUE(KINESIS_MANAGER_STATUS_SUCCEEDED(setup_result));
 }
 
+TEST_F(KinesisVideoStreamerTestBase, invalidCallbackShouldReturnFalse)
+{
+  RosStreamSubscriptionInstaller * real_subscription_installer;
+  real_subscription_installer = new RosStreamSubscriptionInstaller(handle);
+  ASSERT_EQ(real_subscription_installer->SetupImageTransport(nullptr), false);
+  ASSERT_EQ(real_subscription_installer->SetupKinesisVideoFrameTransport(nullptr), false);
+  ASSERT_EQ(real_subscription_installer->SetupRekognitionEnabledKinesisVideoFrameTransport(nullptr), false);
+}
+
 TEST_F(KinesisVideoStreamerTestBase, codecPrivateDataFailure)
 {
   int stream_count = 100;
@@ -267,18 +276,18 @@ protected:
       ros::getGlobalCallbackQueue()->callOne(ros::WallDuration(kSingleCallbackWaitTime));
     }
     /* One of these will hold true depending on whether we're dealing with the mocked or the real
-     * callbacks. */
+    * callbacks. */
     ROS_POSTCALLBACK_ASSERT_TRUE(test_data.kinesis_video_frame_callback_call_count ==
-                                   publish_call_count ||
-                                 test_data.put_frame_call_count == publish_call_count);
+                                  publish_call_count ||
+                                test_data.put_frame_call_count == publish_call_count);
     ASSERT_EQ(test_data.image_callback_call_count, 0);
     if (test_data.put_frame_call_count == publish_call_count) {
       ASSERT_EQ(test_data.process_codec_private_data_call_count, publish_call_count);
     }
 
     /**
-     * Image transport callback test
-     */
+    * Image transport callback test
+    */
     test_data.Reset();
     subscription_topic_name = string("test1");
     parameter_reader.int_map_.at("kinesis_video/stream0/topic_type") =
@@ -301,7 +310,7 @@ protected:
     }
     ASSERT_EQ(test_data.kinesis_video_frame_callback_call_count, 0);
     ROS_POSTCALLBACK_ASSERT_TRUE(test_data.image_callback_call_count == publish_call_count ||
-                                 test_data.put_frame_call_count == publish_call_count);
+                                test_data.put_frame_call_count == publish_call_count);
 
     /**
      * Kinesis Video Frame + Rekognition

--- a/kinesis_video_streamer/test/streamer_node_test.cpp
+++ b/kinesis_video_streamer/test/streamer_node_test.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <aws/core/Aws.h>
+#include <kinesis_video_streamer/ros_stream_subscription_installer.h>
+#include <kinesis_video_streamer/streamer.h>
+#include <kinesis_video_streamer/subscriber_callbacks.h>
+#include <ros/ros.h>
+
+using ::testing::Eq;
+using ::testing::Return;
+using ::testing::AtLeast;
+using Aws::AwsError;
+
+using namespace Aws::Kinesis;
+
+class MockRosStreamSubscriptionInstaller : public RosStreamSubscriptionInstaller
+{
+public:
+  MockRosStreamSubscriptionInstaller(ros::NodeHandle & handle) : RosStreamSubscriptionInstaller(handle) {}
+  
+  MOCK_METHOD0(SetDefaultCallbacks, bool());
+  MOCK_METHOD1(SetupImageTransport, bool(const ImageTransportCallbackFn callback));
+  MOCK_METHOD1(set_stream_manager, void(KinesisStreamManagerInterface * stream_manager));
+};
+
+class TestStreamerNode : public ::testing::Test
+{
+protected:
+  std::shared_ptr<MockRosStreamSubscriptionInstaller> mock_subscription_installer_;
+  std::shared_ptr<StreamerNode> streamer_node_;
+  
+  void SetUp() override
+  {
+    streamer_node_ = std::make_shared<StreamerNode>("~");
+    mock_subscription_installer_ = std::make_shared<MockRosStreamSubscriptionInstaller>(*streamer_node_);
+    streamer_node_->set_subscription_installer(mock_subscription_installer_);
+  }
+  
+  void TearDown() override
+  {
+    streamer_node_.reset();
+    mock_subscription_installer_.reset();
+  }
+};
+
+TEST_F(TestStreamerNode, CreateNode)
+{
+  EXPECT_TRUE(true);
+}
+
+TEST_F(TestStreamerNode, InitializeStreamerNode)
+{
+  EXPECT_CALL(*mock_subscription_installer_, SetDefaultCallbacks())
+    .Times(AtLeast(1)).WillRepeatedly(Return(true));
+  KinesisManagerStatus initialize_result = streamer_node_->Initialize();
+  EXPECT_TRUE(KINESIS_MANAGER_STATUS_SUCCEEDED(initialize_result));
+}
+
+int main(int argc, char ** argv)
+{
+  Aws::SDKOptions options_;
+  Aws::InitAPI(options_);
+    
+  testing::InitGoogleMock(&argc, argv);
+
+  ros::init(argc, argv, "test_streamer_node");
+  ros::NodeHandle n("test_streamer_node");
+  n.setParam("aws_client_configuration/region", "us-west-2");
+  int ret = RUN_ALL_TESTS();
+
+  return ret;
+}

--- a/kinesis_video_streamer/test/test_streamer_node.test
+++ b/kinesis_video_streamer/test/test_streamer_node.test
@@ -1,0 +1,3 @@
+<launch>
+    <test test-name="test_streamer_node" pkg="kinesis_video_streamer" type="test_streamer_node" />
+</launch>


### PR DESCRIPTION
**Changes**
* Refactor the StreamerNode into its own class without the main()
function so that it can have its own test suite.
* Split Initialize function into two to be able to unit tests the initialization
without mocking out the remote kinesis calls in stream setup.
* Add more tests to improve code coverage.

**Notes**

- I didn't like splitting the StreamerNode Initialize function into two sections, however I couldn't figure out a way of testing `KinesisVideoStreamerSetup` without mocking the `KinesisStreamManager` which would require creating a new KinesisStreamManager Factory that would produce a mock object which i could then use to mock the functions `KinesisVideoStreamerSetup`, `InitializeVideoProducer` etc. If anyone knows of an easier way to mock this without some major refactoring please let me know. 


**Code Coverage Results:**

Overall coverage rate:
  lines......: 85.8% (497 of 579 lines)
  functions..: 89.4% (126 of 141 functions)
  branches...: 32.5% (596 of 1832 branches)

*Issue #, if available:* ROS-952



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
