### PR TITLE
use log4cplus from apt

### DIFF
--- a/kinesis_video_streamer/src/streamer.cpp
+++ b/kinesis_video_streamer/src/streamer.cpp
@@ -12,6 +12,9 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+#include <log4cplus/configurator.h>
+
 #include <aws/core/Aws.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws_common/sdk_utils/aws_error.h>

--- a/kinesis_video_streamer/test/kinesis_video_streamer_test_utils.h
+++ b/kinesis_video_streamer/test/kinesis_video_streamer_test_utils.h
@@ -246,13 +246,15 @@ struct MockStreamManager : public KinesisStreamManagerInterface
     std::string region, unique_ptr<DeviceInfoProvider> device_info_provider,
     unique_ptr<ClientCallbackProvider> client_callback_provider,
     unique_ptr<StreamCallbackProvider> stream_callback_provider,
-    unique_ptr<CredentialProvider> credential_provider) override
+    unique_ptr<CredentialProvider> credential_provider,
+    VideoProducerFactory video_producer_factory) override
   {
     data_->initialize_video_producer_call_count++;
     return data_->initialize_video_producer_return_value;
   }
 
-  KinesisManagerStatus InitializeVideoProducer(std::string region) override
+  KinesisManagerStatus InitializeVideoProducer(std::string region,
+    VideoProducerFactory video_producer_factory) override
   {
     data_->initialize_video_producer_call_count++;
     return data_->initialize_video_producer_return_value;


### PR DESCRIPTION
*Description of changes:*

With the `kinesis_manager` package using version 1.7.8 of the KVS Producer SDK, the `log4cplus` dependency will now come from APT, which is now a different version of `log4cplus`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.