### PR TITLE
Remove conditions on ROS version in package.xml

### DIFF
--- a/kinesis_video_streamer/package.xml
+++ b/kinesis_video_streamer/package.xml
@@ -20,10 +20,8 @@
   <depend>image_transport</depend>
   <depend>std_msgs</depend>
 
-  <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
-  <test_depend condition="$ROS_VERSION == 1">google-mock</test_depend>
-  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
-  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gmock</test_depend>
+  <test_depend>gtest</test_depend>
+  <test_depend>google-mock</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>rostopic</test_depend>
 </package>


### PR DESCRIPTION
This is a ROS1-specific package - it that seems these conditionals were added in error. Let's remove them to avoid confusion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
