### PR TITLE
Remove using namespace std, which causes name collisions with boost

### DIFF
--- a/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
+++ b/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
@@ -52,7 +52,6 @@ constexpr double kMultipleCallbacksWaitTime = 5;
   }                                                                                             \
   ASSERT_TRUE(expr)
 
-using namespace std;
 using namespace Aws::Kinesis;
 using namespace Aws::Utils::Logging;
 

--- a/kinesis_video_streamer/test/kinesis_video_streamer_test_utils.h
+++ b/kinesis_video_streamer/test/kinesis_video_streamer_test_utils.h
@@ -20,7 +20,6 @@
 #include <kinesis_video_streamer/ros_stream_subscription_installer.h>
 #include <kinesis_video_streamer/streamer.h>
 
-using namespace std;
 using namespace com::amazonaws::kinesis::video;
 using namespace Aws;
 using namespace Aws::Client;


### PR DESCRIPTION
The Melodic Travis build is currently failing due to ambiguity between std::chrono and boost::chrono. Remove `using namespace std;` to solve this.