### PR TITLE
Add option to enable/disable at runtime

### DIFF
--- a/kinesis_video_streamer/CMakeLists.txt
+++ b/kinesis_video_streamer/CMakeLists.txt
@@ -21,8 +21,21 @@ find_package(catkin REQUIRED COMPONENTS
         kinesis_video_msgs
         roscpp
         image_transport
+        message_generation
         std_msgs)
-catkin_package()
+
+
+add_service_files(
+        DIRECTORY srv
+        FILES
+        Command.srv
+)
+generate_messages()
+
+catkin_package(
+        CATKIN_DEPENDS
+        message_runtime
+)
 
 ###########
 ## Build ##
@@ -37,6 +50,9 @@ target_include_directories(${PROJECT_NAME}_lib PUBLIC include ${catkin_INCLUDE_D
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${kinesis_manager_LIBRARIES} ${PRODUCER_LIBRARY} ${LOG_LIBRARY} ${CURL_LIBRARIES})
 target_link_libraries(${PROJECT_NAME}_lib ${catkin_LIBRARIES} ${kinesis_manager_LIBRARIES} ${PRODUCER_LIBRARY} ${CURL_LIBRARIES})
+## Specify dependencies
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_lib ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 #############
 ## Install ##

--- a/kinesis_video_streamer/include/kinesis_video_streamer/streamer.h
+++ b/kinesis_video_streamer/include/kinesis_video_streamer/streamer.h
@@ -16,6 +16,7 @@
 
 #include <ros/ros.h>
 #include <aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h>
+#include <kinesis_video_streamer/Command.h>
 
 namespace Aws {
 namespace Kinesis {
@@ -40,6 +41,14 @@ public:
   
   KinesisManagerStatus InitializeStreamSubscriptions();
   
+  KinesisManagerStatus UninitializeStreamSubscriptions();
+
+  bool CommandCb(kinesis_video_streamer::Command::Request &req, kinesis_video_streamer::Command::Response &res);
+
+  bool Command(bool enable);
+
+  void PublishStatus(bool enable);
+
   void Spin();
   
   void set_subscription_installer(std::shared_ptr<RosStreamSubscriptionInstaller> subscription_installer);
@@ -49,6 +58,9 @@ private:
   std::shared_ptr<RosStreamSubscriptionInstaller> subscription_installer_;
   std::shared_ptr<KinesisStreamManager> stream_manager_;
   StreamDefinitionProvider stream_definition_provider_;
+  ros::ServiceServer srv_command_;
+  ros::Publisher pub_enabled_;
+  bool enabled_;
 };
 
 }  // namespace Kinesis

--- a/kinesis_video_streamer/package.xml
+++ b/kinesis_video_streamer/package.xml
@@ -12,6 +12,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>message_generation</build_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+
   <depend>aws_common</depend>
   <depend>aws_ros1_common</depend>
   <depend>kinesis_manager</depend>

--- a/kinesis_video_streamer/src/main.cpp
+++ b/kinesis_video_streamer/src/main.cpp
@@ -61,11 +61,6 @@ int main(int argc, char * argv[])
     return shutdown(options, status);
   }
   
-  status = streamer.InitializeStreamSubscriptions();
-  if (!KINESIS_MANAGER_STATUS_SUCCEEDED(status)) {
-    return shutdown(options, status);
-  }
-  
   AWS_LOG_INFO(__func__, "Starting Kinesis Video Node...");
   streamer.Spin();
   

--- a/kinesis_video_streamer/srv/Command.srv
+++ b/kinesis_video_streamer/srv/Command.srv
@@ -1,0 +1,4 @@
+# Command Kinesis video stream node
+
+bool enable
+---


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implements #73.
Streaming can be enabled/disabled with `command` service of custom type.
Initial status on start-up is read from `kinesis_video/enabled` parameter.
Streaming status is reported on `enabled` topic of type `std_msgs/Bool`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
